### PR TITLE
Fix Vercel deployment: Allow images and video, exclude only audio files

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,5 +1,8 @@
-public/uploads/*
-public/hero.mp4
+public/uploads/*.mp3
+public/uploads/*.m4a
+public/uploads/*.wav
+public/uploads/*.aac
+public/uploads/*.ogg
 public/bio/*
 public/Discographythumbnails/*
 public/press-kit/*

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -12,8 +12,11 @@ const nextConfig = {
   experimental: {
         outputFileTracingExcludes: {
           '*': [
-            'public/uploads/**',
-            'public/hero.mp4',
+            'public/uploads/*.mp3',
+            'public/uploads/*.m4a',
+            'public/uploads/*.wav',
+            'public/uploads/*.aac',
+            'public/uploads/*.ogg',
             'public/bio/**',
             'public/Discographythumbnails/**',
             'public/press-kit/**',


### PR DESCRIPTION
- Updated .vercelignore to exclude only audio files (*.mp3, *.m4a, etc.)
- Updated next.config.mjs to exclude only audio files from build
- Images and video will now be included in deployment
- Audio files still excluded to stay under size limits