### PR TITLE
Update metadata titles to reflect Peedu Kass as an Educator

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,11 +4,11 @@ import BandsSection from "@/components/bands-section"
 import AwardsSection from "@/components/awards-section"
 
 export const metadata = {
-  title: "About - Peedu Kass | Bassist, Composer & Musician",
+  title: "About - Peedu Kass | Bassist, Composer & Educator",
   description: "Learn more about Peedu Kass, acclaimed Estonian bassist, composer and educator. Discover his musical journey, bands, awards, and achievements.",
   keywords: "Peedu Kass, about, biography, bassist, composer, Estonian musician, bands, awards, achievements",
   openGraph: {
-    title: "About - Peedu Kass | Bassist, Composer & Musician",
+    title: "About - Peedu Kass | Bassist, Composer & Educator",
     description: "Learn more about Peedu Kass, acclaimed Estonian bassist, composer and educator. Discover his musical journey, bands, awards, and achievements.",
     images: [
       {
@@ -20,7 +20,7 @@ export const metadata = {
     ],
   },
   twitter: {
-    title: "About - Peedu Kass | Bassist, Composer & Musician",
+    title: "About - Peedu Kass | Bassist, Composer & Educator",
     description: "Learn more about Peedu Kass, acclaimed Estonian bassist, composer and educator. Discover his musical journey, bands, awards, and achievements.",
     images: ["https://peedukass.com/uploads/1_photo_by_Martin_Heinmets.webp"],
   },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ const beVietnam = Be_Vietnam_Pro({
 })
 
 export const metadata: Metadata = {
-  title: "Peedu Kass - Bassist, Composer & Musician",
+  title: "Peedu Kass - Bassist, Composer & Educator",
   description: "Official website of Peedu Kass - Estonian bassist, composer, and musician. Explore music, performances, press kit, and more.",
   keywords: "Peedu Kass, bassist, composer, musician, Estonian music, jazz, bass guitar, performances, discography",
   authors: [{ name: "Peedu Kass" }],
@@ -47,7 +47,7 @@ export const metadata: Metadata = {
     locale: "en_US",
     url: "https://peedukass.com",
     siteName: "Peedu Kass",
-    title: "Peedu Kass - Bassist, Composer & Musician",
+    title: "Peedu Kass - Bassist, Composer & Educator",
     description: "Official website of Peedu Kass - Estonian bassist, composer, and musician. Explore music, performances, press kit, and more.",
     images: [
       {
@@ -60,7 +60,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Peedu Kass - Bassist, Composer & Musician",
+    title: "Peedu Kass - Bassist, Composer & Educator",
     description: "Official website of Peedu Kass - Estonian bassist, composer, and musician. Explore music, performances, press kit, and more.",
     images: ["https://peedukass.com/og-image.webp"],
     creator: "@peedukass",


### PR DESCRIPTION
- Changed titles in layout.tsx and about/page.tsx to replace "Musician" with "Educator"
- Ensured consistency across metadata for improved clarity on Peedu Kass's role